### PR TITLE
Bug Fix : Symbol format in price service

### DIFF
--- a/src/domains/analysis/technical/services/price/unified-price.service.ts
+++ b/src/domains/analysis/technical/services/price/unified-price.service.ts
@@ -49,12 +49,12 @@ export class UnifiedPriceService {
    * @returns Array of price data
    */
   async getHistoricalPrices(
-    platform: Platform,
+    platform: 'paradex' | 'avnu',
     identifier: string,
     timeframe: TimeFrame,
     options: BasePriceOptions = {},
   ): Promise<PriceDTO[]> {
-    const service = this.getPriceService(platform);
+    const service = platform === 'paradex' ? this.paradexService : this.avnuService;
     return service.getHistoricalPrices(identifier, timeframe, options);
   }
 


### PR DESCRIPTION
Paradex API calls were failing due to malformed market symbols (BTC-USD-PERP-USD-PERP instead of BTC-USD-PERP), so we fixed the market symbol formation in getMarketSymbol.