### PR TITLE
feat/agent-performance-metrics

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,11 +91,18 @@ model LatestMarketData {
   bondingStatus  BondingStatus @default(BONDING)
   updatedAt      DateTime      @updatedAt
   createdAt      DateTime      @default(now())
+  forkCount      Int           @default(0)
+  pnlCycle       Float         @default(0)
+  pnl24h         Float         @default(0)
+  tradeCount     Int           @default(0)
+  tvl            Float         @default(0)
   elizaAgent     ElizaAgent    @relation(fields: [elizaAgentId], references: [id])
 
   @@index([price])
   @@index([priceChange24h])
   @@index([marketCap])
+  @@index([tvl])
+  @@index([pnl24h])
   @@map("latest_market_data")
 }
 
@@ -174,6 +181,9 @@ model ElizaAgent {
   updatedAt            DateTime             @updatedAt
   accessCodeId         String?
   accessGrantedAt      DateTime?
+  forkedFromId         String?
+  forkedFrom           ElizaAgent?          @relation("AgentForks", fields: [forkedFromId], references: [id])
+  forks                ElizaAgent[]         @relation("AgentForks")
   Token                AgentToken?
   Wallet               AgentWallet?
   accessCode           AccessCode?          @relation(fields: [accessCodeId], references: [id])

--- a/src/domains/leftcurve-agent/dtos/agent-creation-response.dto.ts
+++ b/src/domains/leftcurve-agent/dtos/agent-creation-response.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ForkDetailsDto {
+  @ApiProperty({
+    description: 'ID of the source agent this was forked from',
+    example: '123e4567-e89b-12d3-a456-426614174000'
+  })
+  sourceAgentId: string;
+
+  @ApiProperty({
+    description: 'Name of the source agent',
+    example: 'TradingBot123'
+  })
+  sourceAgentName: string;
+}
+
+export class AgentCreationDataDto {
+  @ApiProperty({
+    description: 'Orchestration ID for tracking the creation process',
+    example: '123e4567-e89b-12d3-a456-426614174000'
+  })
+  orchestrationId: string;
+
+  @ApiProperty({
+    description: 'Status message',
+    example: 'Agent creation initiated successfully'
+  })
+  message: string;
+
+  @ApiProperty({
+    description: 'Fork details if agent was forked',
+    type: ForkDetailsDto,
+    required: false
+  })
+  forkDetails?: ForkDetailsDto;
+}
+
+export class AgentCreationResponseDto {
+  @ApiProperty({
+    description: 'Status of the API request',
+    example: 'success'
+  })
+  status: string;
+
+  @ApiProperty({
+    description: 'Response data',
+    type: AgentCreationDataDto
+  })
+  data: AgentCreationDataDto;
+} 

--- a/src/domains/leftcurve-agent/dtos/eliza-agent-response.dto.ts
+++ b/src/domains/leftcurve-agent/dtos/eliza-agent-response.dto.ts
@@ -1,0 +1,79 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AgentStatus, CurveSide } from '@prisma/client';
+import { LatestMarketDataDto } from './latest-market-data.dto';
+
+export class ElizaAgentResponseDto {
+  @ApiProperty({ description: 'Unique identifier' })
+  id: string;
+
+  @ApiProperty({ description: 'Agent name' })
+  name: string;
+
+  @ApiProperty({ 
+    description: 'Side of the curve',
+    enum: CurveSide 
+  })
+  curveSide: CurveSide;
+
+  @ApiProperty({ description: 'Creator wallet address' })
+  creatorWallet: string;
+
+  @ApiProperty({ description: 'Deployment fees transaction hash' })
+  deploymentFeesTxHash: string;
+
+  @ApiProperty({ 
+    description: 'Current status of the agent',
+    enum: AgentStatus 
+  })
+  status: AgentStatus;
+
+  @ApiProperty({ description: 'Reason for failure if status is FAILED', required: false })
+  failureReason?: string;
+
+  @ApiProperty({ description: 'Docker container ID', required: false })
+  containerId?: string;
+
+  @ApiProperty({ description: 'Runtime agent ID', required: false })
+  runtimeAgentId?: string;
+
+  @ApiProperty({ description: 'Port number the agent is running on', required: false })
+  port?: number;
+
+  @ApiProperty({ description: 'Character configuration' })
+  characterConfig: any;
+
+  @ApiProperty({ description: 'Profile picture filename', required: false })
+  profilePicture?: string;
+
+  @ApiProperty({ description: 'Profile picture URL', required: false })
+  profilePictureUrl?: string;
+
+  @ApiProperty({ description: 'Agent creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: Date;
+
+  @ApiProperty({ description: 'Degen score', required: false })
+  degenScore?: number;
+
+  @ApiProperty({ description: 'Win score', required: false })
+  winScore?: number;
+
+  // Fork relationship fields
+  @ApiProperty({ description: 'ID of the agent this was forked from', required: false })
+  forkedFromId?: string;
+
+  @ApiProperty({ description: 'Source agent this was forked from', required: false })
+  forkedFrom?: ElizaAgentResponseDto;
+
+  @ApiProperty({ 
+    description: 'Agents that were forked from this agent',
+    type: [ElizaAgentResponseDto],
+    required: false
+  })
+  forks?: ElizaAgentResponseDto[];
+
+  @ApiProperty({ description: 'Latest market data', type: LatestMarketDataDto, required: false })
+  latestMarketData?: LatestMarketDataDto;
+} 

--- a/src/domains/leftcurve-agent/dtos/latest-market-data.dto.ts
+++ b/src/domains/leftcurve-agent/dtos/latest-market-data.dto.ts
@@ -1,0 +1,66 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { BondingStatus } from '@prisma/client';
+
+export class LatestMarketDataDto {
+  @ApiProperty({ description: 'Unique identifier' })
+  id: string;
+
+  @ApiProperty({ description: 'Associated agent ID' })
+  elizaAgentId: string;
+
+  @ApiProperty({ description: 'Current token price' })
+  price: number;
+
+  @ApiProperty({ description: '24-hour price change percentage' })
+  priceChange24h: number;
+
+  @ApiProperty({ description: 'Number of token holders' })
+  holders: number;
+
+  @ApiProperty({ description: 'Market capitalization' })
+  marketCap: number;
+
+  @ApiProperty({ 
+    description: 'Bonding status',
+    enum: BondingStatus,
+    example: BondingStatus.BONDING
+  })
+  bondingStatus: BondingStatus;
+
+  // New performance metrics
+  @ApiProperty({ 
+    description: 'Number of times this agent has been forked',
+    example: 5
+  })
+  forkCount: number;
+
+  @ApiProperty({ 
+    description: 'Profit/loss for the current trading cycle',
+    example: 123.45
+  })
+  pnlCycle: number;
+
+  @ApiProperty({ 
+    description: 'Profit/loss for the last 24 hours',
+    example: 45.67
+  })
+  pnl24h: number;
+
+  @ApiProperty({ 
+    description: 'Total number of trades executed',
+    example: 42
+  })
+  tradeCount: number;
+
+  @ApiProperty({ 
+    description: 'Total value locked/under management',
+    example: 10000.00
+  })
+  tvl: number;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: Date;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: Date;
+} 

--- a/src/domains/leftcurve-agent/dtos/leftcurve-agent.dto.ts
+++ b/src/domains/leftcurve-agent/dtos/leftcurve-agent.dto.ts
@@ -5,6 +5,7 @@ import {
   IsObject,
   IsNotEmpty,
   IsOptional,
+  IsUUID,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { CurveSide } from '@prisma/client';
@@ -41,6 +42,15 @@ export class CreateElizaAgentDto {
   @IsString()
   @IsNotEmpty()
   transactionHash: string;
+
+  @ApiProperty({
+    description: 'ID of the agent to fork from (optional)',
+    required: false,
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsUUID()
+  @IsOptional()
+  forkedFromId?: string;
 
   @ApiProperty({
     description: "Agent's character configuration (legacy format)",

--- a/src/domains/leftcurve-agent/entities/leftcurve-agent.entity.ts
+++ b/src/domains/leftcurve-agent/entities/leftcurve-agent.entity.ts
@@ -1,5 +1,5 @@
 import { JsonValue } from '@prisma/client/runtime/library';
-import { AgentStatus, CurveSide } from '@prisma/client';
+import { AgentStatus, BondingStatus, CurveSide } from '@prisma/client';
 import { AgentWallet } from './agent-wallet.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -12,6 +12,13 @@ export class AgentToken {
   contractAddress: string;
   buyTax: number;
   sellTax: number;
+  elizaAgentId: string;
+}
+
+export class TradingInformation {
+  id: string;
+  createdAt: Date;
+  information: any;
   elizaAgentId: string;
 }
 
@@ -35,6 +42,10 @@ export class ElizaAgent {
   tradingInformation?: TradingInformation[];
   token?: AgentToken;
   wallet?: AgentWallet;
+  // Fork relationship fields
+  forkedFromId?: string;
+  forkedFrom?: ElizaAgent;
+  forks?: ElizaAgent[];
 
   @ApiProperty({
     description: "URL to the agent's profile picture",
@@ -59,13 +70,17 @@ export class LatestMarketData {
   priceChange24h: number;
   holders: number;
   marketCap: number;
+  bondingStatus: BondingStatus;
   updatedAt: Date;
   createdAt: Date;
-}
+  // New performance metrics
+  forkCount: number;
+  pnlCycle: number;
+  pnl24h: number;
+  tradeCount: number;
+  tvl: number;
 
-export class TradingInformation {
-  id: string;
-  elizaAgentId: string;
-  information: JsonValue;
-  createdAt: Date;
+  constructor(partial: Partial<LatestMarketData>) {
+    Object.assign(this, partial);
+  }
 }

--- a/src/domains/leftcurve-agent/leftcurve-agent.controller.ts
+++ b/src/domains/leftcurve-agent/leftcurve-agent.controller.ts
@@ -24,7 +24,8 @@ import {
 import { LoggingInterceptor } from '../../shared/interceptors/logging.interceptor';
 import { RequireApiKey } from '../../shared/auth/decorators/require-api-key.decorator';
 import { CreateElizaAgentDto } from './dtos/leftcurve-agent.dto';
-import { ElizaAgent } from './entities/leftcurve-agent.entity';
+import { ElizaAgentResponseDto } from './dtos/eliza-agent-response.dto';
+import { AgentCreationResponseDto } from './dtos/agent-creation-response.dto';
 import {
   IElizaAgentQueryService,
   IElizaAgentLifecycleService,
@@ -60,6 +61,7 @@ export class ElizaAgentController {
   @ApiResponse({
     status: 202,
     description: 'Agent creation initiated',
+    type: AgentCreationResponseDto
   })
   @ApiResponse({
     status: 400,
@@ -88,7 +90,7 @@ export class ElizaAgentController {
   async createAgent(
     @Body() dto: CreateElizaAgentDto,
     @UploadedFile() file?: Express.Multer.File,
-  ) {
+  ): Promise<AgentCreationResponseDto> {
     let tempFileName = null;
 
     try {
@@ -281,7 +283,7 @@ export class ElizaAgentController {
   @ApiResponse({
     status: 200,
     description: 'List of agents retrieved successfully',
-    type: [ElizaAgent],
+    type: [ElizaAgentResponseDto],
   })
   async listAgents() {
     const agents = await this.queryService.listAgents();
@@ -297,7 +299,7 @@ export class ElizaAgentController {
   @ApiResponse({
     status: 200,
     description: 'List of running agents retrieved successfully',
-    type: [ElizaAgent],
+    type: [ElizaAgentResponseDto],
   })
   async listRunningAgents() {
     const agents = await this.queryService.listRunningAgents();
@@ -313,7 +315,7 @@ export class ElizaAgentController {
   @ApiResponse({
     status: 200,
     description: 'List of latest agents retrieved successfully',
-    type: [ElizaAgent],
+    type: [ElizaAgentResponseDto],
   })
   async listLatestAgents() {
     const agents = await this.queryService.listLatestAgents();
@@ -329,7 +331,7 @@ export class ElizaAgentController {
   @ApiResponse({
     status: 200,
     description: 'List of matching agents retrieved successfully',
-    type: [ElizaAgent],
+    type: [ElizaAgentResponseDto],
   })
   async searchAgents(@Query('term') searchTerm: string) {
     if (!searchTerm || searchTerm.trim().length === 0) {
@@ -353,7 +355,7 @@ export class ElizaAgentController {
   @ApiResponse({
     status: 200,
     description: 'Agent retrieved successfully',
-    type: ElizaAgent,
+    type: ElizaAgentResponseDto,
   })
   async getAgent(@Param('id') id: string) {
     const agent = await this.queryService.getAgent(id);

--- a/src/domains/market-data/dtos/update-market-data.dto.ts
+++ b/src/domains/market-data/dtos/update-market-data.dto.ts
@@ -1,0 +1,96 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsNumber, IsEnum, IsInt } from 'class-validator';
+import { BondingStatus } from '@prisma/client';
+
+export class UpdateMarketDataDto {
+  @ApiProperty({ 
+    description: 'Current token price',
+    example: 0.5,
+    required: false
+  })
+  @IsNumber()
+  @IsOptional()
+  price?: number;
+
+  @ApiProperty({ 
+    description: '24-hour price change percentage',
+    example: 5.25,
+    required: false
+  })
+  @IsNumber()
+  @IsOptional()
+  priceChange24h?: number;
+
+  @ApiProperty({ 
+    description: 'Number of token holders',
+    example: 100,
+    required: false
+  })
+  @IsInt()
+  @IsOptional()
+  holders?: number;
+
+  @ApiProperty({ 
+    description: 'Market capitalization',
+    example: 50000,
+    required: false
+  })
+  @IsNumber()
+  @IsOptional()
+  marketCap?: number;
+
+  @ApiProperty({ 
+    description: 'Bonding status',
+    enum: BondingStatus,
+    example: BondingStatus.BONDING,
+    required: false
+  })
+  @IsEnum(BondingStatus)
+  @IsOptional()
+  bondingStatus?: BondingStatus;
+
+  @ApiProperty({ 
+    description: 'Number of times this agent has been forked',
+    example: 5,
+    required: false
+  })
+  @IsInt()
+  @IsOptional()
+  forkCount?: number;
+
+  @ApiProperty({ 
+    description: 'Profit/loss for the current trading cycle',
+    example: 123.45,
+    required: false
+  })
+  @IsNumber()
+  @IsOptional()
+  pnlCycle?: number;
+
+  @ApiProperty({ 
+    description: 'Profit/loss for the last 24 hours',
+    example: 45.67,
+    required: false
+  })
+  @IsNumber()
+  @IsOptional()
+  pnl24h?: number;
+
+  @ApiProperty({ 
+    description: 'Total number of trades executed',
+    example: 42,
+    required: false
+  })
+  @IsInt()
+  @IsOptional()
+  tradeCount?: number;
+
+  @ApiProperty({ 
+    description: 'Total value locked/under management',
+    example: 10000.00,
+    required: false
+  })
+  @IsNumber()
+  @IsOptional()
+  tvl?: number;
+} 

--- a/src/domains/market-data/services/latest-market-data.service.ts
+++ b/src/domains/market-data/services/latest-market-data.service.ts
@@ -3,14 +3,21 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../../shared/prisma/prisma.service';
 import { ILatestMarketDataService } from '../interfaces/latest-market-data.interface';
 import { LatestMarketData } from 'src/domains/leftcurve-agent/entities/leftcurve-agent.entity';
+import { UpdateMarketDataDto } from '../dtos/update-market-data.dto';
 
 @Injectable()
 export class ElizaAgentCreateService implements ILatestMarketDataService {
   constructor(private readonly prisma: PrismaService) {}
 
+  /**
+   * Updates market data for an agent, including all the new performance metrics
+   * @param agentId ID of the agent to update
+   * @param marketData Market data to update
+   * @returns The updated market data record
+   */
   async updateMarketData(
     agentId: string,
-    marketData: Partial<LatestMarketData>,
+    marketData: Partial<LatestMarketData> | UpdateMarketDataDto,
   ): Promise<LatestMarketData> {
     return this.prisma.latestMarketData.upsert({
       where: { elizaAgentId: agentId },
@@ -19,6 +26,49 @@ export class ElizaAgentCreateService implements ILatestMarketDataService {
         ...marketData,
       },
       update: marketData,
+    });
+  }
+
+  /**
+   * Updates performance metrics for an agent
+   * @param agentId ID of the agent to update
+   * @param data Performance metrics to update (pnl, tvl, etc.)
+   * @returns The updated market data record
+   */
+  async updatePerformanceMetrics(
+    agentId: string, 
+    data: {
+      pnlCycle?: number;
+      pnl24h?: number;
+      tradeCount?: number;
+      tvl?: number;
+    }
+  ): Promise<LatestMarketData> {
+    return this.prisma.latestMarketData.update({
+      where: { elizaAgentId: agentId },
+      data
+    });
+  }
+
+  /**
+   * Increments the fork count for an agent
+   * @param agentId ID of the agent that was forked
+   * @returns The updated market data record with incremented fork count
+   */
+  async incrementForkCount(agentId: string): Promise<LatestMarketData> {
+    const marketData = await this.prisma.latestMarketData.findUnique({
+      where: { elizaAgentId: agentId }
+    });
+    
+    if (!marketData) {
+      throw new Error(`Market data not found for agent ${agentId}`);
+    }
+    
+    return this.prisma.latestMarketData.update({
+      where: { elizaAgentId: agentId },
+      data: { 
+        forkCount: marketData.forkCount + 1 
+      }
     });
   }
 }


### PR DESCRIPTION
# Agent Performance Metrics and Forking Capability

This PR enhances the agent data model with performance metrics and forking capabilities to support our consolidated agent data endpoint (Issue #71).

## Changes Made

### Schema Enhancements
- Added performance metrics to `LatestMarketData`:
  - `forkCount`: Tracks how many times an agent has been forked
  - `pnlCycle`: Profit/loss for the current trading cycle 
  - `pnl24h`: Profit/loss for the last 24 hours
  - `tradeCount`: Total number of trades executed
  - `tvl`: Total value locked/under management
- Added fork relationship to `ElizaAgent`:
  - `forkedFromId`: ID of the agent this was forked from
  - Self-referencing relationship for tracking agent lineage
- Created appropriate indexes for efficient querying

### DTO and API Updates
- Created response DTOs with new fields:
  - `ElizaAgentResponseDto`
  - `LatestMarketDataDto` 
  - `AgentCreationResponseDto`
- Added update DTOs with validation:
  - `UpdateMarketDataDto`
- Modified database record creation to handle forking logic
- Enhanced market data service with methods for tracking performance

## Testing
- Verified fields are populated in API responses
- Tested fork count incrementation when agents are forked
- Confirmed all data is correctly included in agent endpoints

## Next Steps
- Implement historical PnL tracking when time-series data becomes available
- Add portfolio history visualization support
- Create dedicated endpoints for performance metrics over time

This foundational work enables the consolidated agent data endpoint (Issue #71) by ensuring all required metrics are available in a single request.

Resolves #71 