### PR TITLE
Feature/add balance and ranking fields

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,6 +96,8 @@ model LatestMarketData {
   pnl24h         Float         @default(0)
   tradeCount     Int           @default(0)
   tvl            Float         @default(0)
+  balanceInUSD   Float         @default(0)
+  pnlRank        Int?
   elizaAgent     ElizaAgent    @relation(fields: [elizaAgentId], references: [id])
 
   @@index([price])
@@ -103,6 +105,7 @@ model LatestMarketData {
   @@index([marketCap])
   @@index([tvl])
   @@index([pnl24h])
+  @@index([pnlRank])
   @@map("latest_market_data")
 }
 

--- a/scripts/simulate-history.js
+++ b/scripts/simulate-history.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+/**
+ * Simulate Multi-Day Performance History
+ *
+ * This script creates performance snapshots for the last 7 days with
+ * appropriate timestamps to populate the daily performance chart.
+ *
+ * Usage: node simulate-history.js
+ */
+
+const axios = require('axios');
+const { PrismaClient } = require('@prisma/client');
+
+// Configuration
+const AGENT_ID = '149507f3-758c-42c6-8f9b-47cbb38e0b97';
+const RUNTIME_AGENT_ID =
+  '53e11e953f967a8dca7b356da01a663dd6b59db2d837e85bbcc708729f4fc732';
+const API_KEY = 'secret';
+const BASE_URL = 'http://127.0.0.1:8080';
+
+// Initialize Prisma client for direct database access
+const prisma = new PrismaClient();
+
+// Helper to create formatted date strings
+const formatDate = (daysAgo) => {
+  const date = new Date();
+  date.setDate(date.getDate() - daysAgo);
+  // Set to noon each day to ensure they're treated as separate days
+  date.setHours(12, 0, 0, 0);
+  return date;
+};
+
+// Clear existing snapshots before creating new ones
+async function clearExistingData() {
+  try {
+    console.log('Clearing existing performance snapshots...');
+    await prisma.agentPerformanceSnapshot.deleteMany({
+      where: { agentId: AGENT_ID },
+    });
+    console.log('✓ Cleared existing snapshots');
+  } catch (error) {
+    console.error('Error clearing snapshots:', error);
+  }
+}
+
+// Create a single snapshot for a specific day
+async function createDailySnapshot(daysAgo, balanceValue, pnlValue) {
+  try {
+    const date = formatDate(daysAgo);
+    console.log(
+      `Creating snapshot for ${date.toISOString()} (${daysAgo} days ago)...`,
+    );
+
+    // Insert snapshot directly into database with the specific date
+    const snapshot = await prisma.agentPerformanceSnapshot.create({
+      data: {
+        agentId: AGENT_ID,
+        timestamp: date,
+        balanceInUSD: balanceValue,
+        pnl: pnlValue,
+        pnlPercentage: (pnlValue / (balanceValue - pnlValue)) * 100,
+        pnl24h:
+          daysAgo < 7 ? balanceValue - (balanceValue - pnlValue) : pnlValue,
+        pnlCycle: 0,
+        tradeCount: 2 + daysAgo, // Increasing trade count over time
+        tvl: 0,
+        price: 0,
+        marketCap: 0,
+      },
+    });
+
+    console.log(`✓ Created snapshot for ${date.toISOString()}`);
+    return snapshot;
+  } catch (error) {
+    console.error(`Error creating snapshot for ${daysAgo} days ago:`, error);
+  }
+}
+
+// Run simulation
+async function simulateWeekHistory() {
+  console.log('Simulating 7-day trading history...');
+
+  try {
+    // First clear existing snapshots
+    await clearExistingData();
+
+    // Create 7 daily snapshots with appropriate timestamps
+    // We'll create them from oldest to newest
+    const snapshots = [
+      { daysAgo: 6, balance: 1000, pnl: 0 }, // Starting point
+      { daysAgo: 5, balance: 1050, pnl: 50 }, // Small growth
+      { daysAgo: 4, balance: 1120, pnl: 120 }, // More growth
+      { daysAgo: 3, balance: 1190, pnl: 190 }, // Add BTC
+      { daysAgo: 2, balance: 1150, pnl: 150 }, // Market dip
+      { daysAgo: 1, balance: 1320, pnl: 320 }, // Recovery
+      { daysAgo: 0, balance: 1536, pnl: 536 }, // Today - Current state
+    ];
+
+    // Create each snapshot
+    for (const day of snapshots) {
+      await createDailySnapshot(day.daysAgo, day.balance, day.pnl);
+      // Small delay to ensure ordering
+      await new Promise((r) => setTimeout(r, 500));
+    }
+
+    console.log('Done! Checking results...');
+
+    // Verify the created history
+    const historyResponse = await axios.get(
+      `${BASE_URL}/api/performance/${AGENT_ID}/history?interval=daily`,
+      {
+        headers: { 'x-api-key': API_KEY },
+      },
+    );
+
+    console.log(
+      'Daily history snapshots:',
+      historyResponse.data.snapshots.length,
+    );
+    console.log('Dates:');
+    for (const snapshot of historyResponse.data.snapshots) {
+      console.log(
+        `  ${new Date(snapshot.timestamp).toLocaleString()} - $${snapshot.balanceInUSD}`,
+      );
+    }
+
+    console.log('\nSimulation complete! Your 7-day history has been created.');
+  } catch (error) {
+    console.error('Error in simulation:', error);
+  } finally {
+    // Always disconnect from prisma
+    await prisma.$disconnect();
+  }
+}
+
+// Execute the simulation
+simulateWeekHistory().catch((error) => console.error('Error:', error));

--- a/src/cron/tasks.module.ts
+++ b/src/cron/tasks.module.ts
@@ -6,6 +6,7 @@ import { PrismaModule } from '../shared/prisma/prisma.module';
 import { AgentTokenModule } from '../domains/agent-token/agent-token.module';
 import { BlockchainModule } from '../shared/blockchain/blockchain.module';
 import { KPIModule } from '../domains/kpi/kpi.module';
+import { SyncPerformanceMetricsTask } from './tasks/sync-performance-metrics.task';
 
 @Module({
   imports: [
@@ -16,6 +17,6 @@ import { KPIModule } from '../domains/kpi/kpi.module';
     BlockchainModule,
     KPIModule,
   ],
-  providers: [TasksService],
+  providers: [TasksService, SyncPerformanceMetricsTask],
 })
 export class TasksModule {}

--- a/src/cron/tasks/sync-performance-metrics.task.ts
+++ b/src/cron/tasks/sync-performance-metrics.task.ts
@@ -1,0 +1,167 @@
+import { Injectable, Logger, Inject } from '@nestjs/common';
+import { PrismaService } from '../../shared/prisma/prisma.service';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import {
+  AccountBalanceTokens,
+  IAccountBalance,
+} from '../../domains/kpi/interfaces';
+
+@Injectable()
+export class SyncPerformanceMetricsTask {
+  private readonly logger = new Logger(SyncPerformanceMetricsTask.name);
+
+  constructor(
+    @Inject(AccountBalanceTokens.AccountBalance)
+    private readonly kpiService: IAccountBalance,
+    private readonly prisma: PrismaService,
+  ) {
+    // Run the task immediately when the server starts
+    this.execute();
+  }
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  async execute(): Promise<void> {
+    const startTime = Date.now();
+    this.logger.log('🔄 Starting performance metrics sync');
+
+    try {
+      // Get all agents with LatestMarketData
+      const agents = await this.prisma.elizaAgent.findMany({
+        include: {
+          LatestMarketData: true,
+        },
+      });
+
+      let updatedCount = 0;
+      let skippedCount = 0;
+
+      // Get all PnL data at once for efficiency
+      const allPnlData = await this.kpiService.getAllAgentsPnL();
+
+      // Create a map for quick lookups
+      const pnlDataMap = new Map();
+      allPnlData.forEach((data) => {
+        pnlDataMap.set(data.agentId, data);
+      });
+
+      // Sync metrics for each agent
+      for (const agent of agents) {
+        try {
+          // Get PnL data from map
+          const pnlData = pnlDataMap.get(agent.id) || {
+            pnl: 0,
+            pnlPercentage: 0,
+          };
+
+          // Get portfolio data for balance calculation
+          let balanceInUSD = 0;
+          try {
+            const portfolioData = await this.kpiService.getAgentPortfolio(
+              agent.runtimeAgentId || agent.id,
+            );
+            balanceInUSD = portfolioData.balanceInUSD || 0;
+          } catch (error) {
+            this.logger.warn(
+              `Could not get portfolio for agent ${agent.id}: ${error.message}`,
+            );
+          }
+
+          // Get trade count
+          const tradeCount = await this.prisma.tradingInformation.count({
+            where: { elizaAgentId: agent.id },
+          });
+
+          // Get 24h PnL from the latest performance snapshot
+          const snapshot = await this.prisma.agentPerformanceSnapshot.findFirst(
+            {
+              where: { agentId: agent.id },
+              orderBy: { timestamp: 'desc' },
+            },
+          );
+
+          // Prepare data to update
+          const updateData = {
+            pnlCycle: pnlData.pnl || 0,
+            pnl24h: snapshot?.pnl24h || 0,
+            tradeCount: tradeCount,
+            tvl: 0, // Keep TVL at 0 per requirements
+            balanceInUSD: balanceInUSD, // Use the new field for balance
+            updatedAt: new Date(),
+          };
+
+          // Update LatestMarketData
+          if (agent.LatestMarketData) {
+            await this.prisma.latestMarketData.update({
+              where: { elizaAgentId: agent.id },
+              data: updateData,
+            });
+          } else {
+            // Create if not exists
+            await this.prisma.latestMarketData.create({
+              data: {
+                elizaAgentId: agent.id,
+                price: 0,
+                priceChange24h: 0,
+                holders: 0,
+                marketCap: 0,
+                bondingStatus: 'BONDING',
+                forkCount: 0,
+                ...updateData,
+              },
+            });
+          }
+
+          updatedCount++;
+          this.logger.debug(
+            `Updated metrics for agent ${agent.id} (${agent.name})`,
+          );
+        } catch (error) {
+          skippedCount++;
+          this.logger.error(
+            `Failed to sync metrics for agent ${agent.id}: ${error.message}`,
+          );
+        }
+      }
+
+      // Sort agents by PnL to determine rankings and update in a separate operation
+      const agentsWithMetrics = await this.prisma.elizaAgent.findMany({
+        include: {
+          LatestMarketData: true,
+        },
+      });
+
+      const sortedAgents = agentsWithMetrics
+        .filter((a) => a.LatestMarketData)
+        .sort(
+          (a, b) =>
+            (b.LatestMarketData.pnlCycle || 0) -
+            (a.LatestMarketData.pnlCycle || 0),
+        );
+
+      // Update rankings directly in the database
+      for (let i = 0; i < sortedAgents.length; i++) {
+        const agent = sortedAgents[i];
+        const rank = i + 1;
+
+        await this.prisma.latestMarketData.update({
+          where: { elizaAgentId: agent.id },
+          data: { pnlRank: rank },
+        });
+
+        this.logger.debug(
+          `Updated rank for agent ${agent.name}: ${rank}, PnL: ${agent.LatestMarketData.pnlCycle}`,
+        );
+      }
+
+      const duration = Date.now() - startTime;
+      this.logger.log(
+        `✅ Performance metrics sync completed - Updated: ${updatedCount}, Skipped: ${skippedCount}, Duration: ${duration}ms`,
+      );
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      this.logger.error(
+        `Failed to complete performance metrics sync (${duration}ms): ${error.message}`,
+      );
+    }
+  }
+}

--- a/src/domains/kpi/controllers/metrics.controller.ts
+++ b/src/domains/kpi/controllers/metrics.controller.ts
@@ -1,0 +1,138 @@
+import {
+  Controller,
+  Get,
+  UseInterceptors,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { LoggingInterceptor } from '../../../shared/interceptors/logging.interceptor';
+import { RequireApiKey } from '../../../shared/auth/decorators/require-api-key.decorator';
+import { PrismaService } from '../../../shared/prisma/prisma.service';
+
+// Type extension for PrismaService to handle models not in schema
+interface ExtendedPrismaModels {
+  paradexAccountBalance: {
+    findFirst: any;
+    findMany: any;
+  };
+}
+
+// Extended PrismaService with additional models
+type ExtendedPrismaService = PrismaService & ExtendedPrismaModels;
+
+@ApiTags('Metrics')
+@Controller('api/metrics')
+@UseInterceptors(LoggingInterceptor)
+export class MetricsController {
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Get('global/agent-count')
+  @RequireApiKey()
+  @ApiOperation({ summary: 'Get total number of agents' })
+  @ApiResponse({
+    status: 200,
+    description: 'Agent count retrieved successfully',
+  })
+  async getTotalAgentCount(): Promise<any> {
+    try {
+      const count = await this.prisma.elizaAgent.count();
+
+      return {
+        totalAgentCount: count,
+      };
+    } catch (error) {
+      throw new InternalServerErrorException(
+        `Failed to get agent count: ${error.message}`,
+      );
+    }
+  }
+
+  @Get('global/trades')
+  @RequireApiKey()
+  @ApiOperation({ summary: 'Get total trade count across all agents' })
+  @ApiResponse({
+    status: 200,
+    description: 'Total trade count retrieved successfully',
+  })
+  async getTotalTradeCount(): Promise<any> {
+    try {
+      // Calculate total trade count by summing up tradeCount from all agents
+      const result = await this.prisma.latestMarketData.aggregate({
+        _sum: {
+          tradeCount: true,
+        },
+      });
+
+      return {
+        totalTradeCount: result._sum.tradeCount || 0,
+      };
+    } catch (error) {
+      throw new InternalServerErrorException(
+        `Failed to calculate total trade count: ${error.message}`,
+      );
+    }
+  }
+
+  @Get('global/tvl')
+  @RequireApiKey()
+  @ApiOperation({ summary: 'Get total TVL across all agents' })
+  @ApiResponse({
+    status: 200,
+    description: 'Total TVL retrieved successfully',
+  })
+  async getTotalTVL(): Promise<any> {
+    try {
+      // Calculate total TVL by summing up TVL from all agents
+      const result = await this.prisma.latestMarketData.aggregate({
+        _sum: {
+          tvl: true,
+        },
+      });
+
+      return {
+        totalTVL: result._sum.tvl || 0,
+      };
+    } catch (error) {
+      throw new InternalServerErrorException(
+        `Failed to calculate total TVL: ${error.message}`,
+      );
+    }
+  }
+
+  @Get('global/balances')
+  @RequireApiKey()
+  @ApiOperation({ summary: 'Get total balance across all agents' })
+  @ApiResponse({
+    status: 200,
+    description: 'Total balance retrieved successfully',
+  })
+  async getTotalBalance(): Promise<any> {
+    try {
+      // For each agent, get their latest balance
+      const agents = await this.prisma.elizaAgent.findMany();
+      let totalBalance = 0;
+
+      const extendedPrisma = this.prisma as ExtendedPrismaService;
+
+      for (const agent of agents) {
+        const latestBalance =
+          await extendedPrisma.paradexAccountBalance.findFirst({
+            where: { agentId: agent.id },
+            orderBy: { createdAt: 'desc' },
+          });
+
+        if (latestBalance) {
+          totalBalance += latestBalance.balanceInUSD;
+        }
+      }
+
+      return {
+        totalBalance,
+      };
+    } catch (error) {
+      throw new InternalServerErrorException(
+        `Failed to calculate total balance: ${error.message}`,
+      );
+    }
+  }
+}

--- a/src/domains/kpi/controllers/performance-snapshot.controller.ts
+++ b/src/domains/kpi/controllers/performance-snapshot.controller.ts
@@ -5,12 +5,18 @@ import {
   Param,
   Query,
   UseInterceptors,
+  Inject,
+  NotFoundException,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags, ApiQuery } from '@nestjs/swagger';
 import { LoggingInterceptor } from '../../../shared/interceptors/logging.interceptor';
 import { RequireApiKey } from '../../../shared/auth/decorators/require-api-key.decorator';
 import { PerformanceSnapshotService } from '../services/performance-snapshot.service';
 import { PerformanceHistoryResponseDto } from '../dtos/performance-snapshot.dto';
+import { AccountBalanceTokens } from '../interfaces';
+import { IAccountBalance } from '../interfaces/kpi.interface';
+import { ServiceTokens } from '../../leftcurve-agent/interfaces';
+import { IElizaAgentQueryService } from '../../leftcurve-agent/interfaces';
 
 @ApiTags('Agent Performance')
 @Controller('api/performance')
@@ -18,7 +24,20 @@ import { PerformanceHistoryResponseDto } from '../dtos/performance-snapshot.dto'
 export class PerformanceSnapshotController {
   constructor(
     private readonly performanceService: PerformanceSnapshotService,
+    @Inject(AccountBalanceTokens.AccountBalance)
+    private readonly balanceAccountService: IAccountBalance,
+    @Inject(ServiceTokens.ElizaAgentQuery)
+    private readonly elizaAgentService: IElizaAgentQueryService,
   ) {}
+
+  // Helper method to get agent by id
+  private async getAgentById(agentId: string) {
+    try {
+      return await this.elizaAgentService.getAgent(agentId);
+    } catch (error) {
+      throw new NotFoundException(`Agent with ID ${agentId} not found`);
+    }
+  }
 
   @Get(':agentId/history')
   @RequireApiKey()
@@ -57,6 +76,64 @@ export class PerformanceSnapshotController {
       toDate,
       interval || 'daily',
     );
+  }
+
+  @Get(':agentId/assets')
+  @RequireApiKey()
+  @ApiOperation({ summary: 'Get asset allocation for an agent' })
+  @ApiResponse({
+    status: 200,
+    description: 'Asset allocation retrieved successfully',
+  })
+  @ApiResponse({ status: 404, description: 'Agent not found' })
+  async getAgentAssetAllocation(
+    @Param('agentId') agentId: string,
+  ): Promise<any> {
+    // First try to find agent by ID, then by runtimeAgentId if needed
+    try {
+      // Get the agent to find its runtimeAgentId
+      const agent = await this.getAgentById(agentId);
+
+      // Get the portfolio data using the runtimeAgentId
+      const portfolioData = await this.balanceAccountService.getAgentPortfolio(
+        agent.runtimeAgentId,
+      );
+
+      // Format the data as expected by frontend
+      return {
+        status: 'success',
+        data: {
+          timestamp: portfolioData.timestamp,
+          totalBalance: portfolioData.balanceInUSD,
+          assets: portfolioData.portfolio.map((token) => ({
+            symbol: token.symbol,
+            allocation: token.percentage / 100, // Convert percentage to decimal
+            balance: token.balance,
+            price: token.price,
+            valueUsd: token.valueUsd,
+          })),
+        },
+      };
+    } catch (error) {
+      // If the first attempt fails, try directly with the provided ID
+      const portfolioData =
+        await this.balanceAccountService.getAgentPortfolio(agentId);
+
+      return {
+        status: 'success',
+        data: {
+          timestamp: portfolioData.timestamp,
+          totalBalance: portfolioData.balanceInUSD,
+          assets: portfolioData.portfolio.map((token) => ({
+            symbol: token.symbol,
+            allocation: token.percentage / 100, // Convert percentage to decimal
+            balance: token.balance,
+            price: token.price,
+            valueUsd: token.valueUsd,
+          })),
+        },
+      };
+    }
   }
 
   @Post(':agentId')

--- a/src/domains/kpi/interfaces/kpi.interface.ts
+++ b/src/domains/kpi/interfaces/kpi.interface.ts
@@ -7,4 +7,7 @@ export interface IAccountBalance {
   getAllAgentsPnL(): Promise<any[]>;
   getBestPerformingAgent(): Promise<any>;
   getAgentPortfolio(runtimeAgentId: string): Promise<any>;
+
+  getAgentBalanceHistory(agentId: string): Promise<any>;
+  getAgentCurrentBalance(agentId: string): Promise<any>;
 }

--- a/src/domains/kpi/kpi.controller.ts
+++ b/src/domains/kpi/kpi.controller.ts
@@ -83,4 +83,32 @@ export class KPIController {
   ): Promise<any> {
     return this.balanceAccountService.getAgentPortfolio(runtimeAgentId);
   }
+
+  @Get('balance/:agentId')
+  @RequireApiKey()
+  @ApiOperation({ summary: 'Get balance history for a specific agent' })
+  @ApiResponse({
+    status: 200,
+    description: 'Balance history retrieved successfully',
+  })
+  @ApiResponse({ status: 404, description: 'Agent not found' })
+  async getAgentBalanceHistory(
+    @Param('agentId') agentId: string,
+  ): Promise<any> {
+    return this.balanceAccountService.getAgentBalanceHistory(agentId);
+  }
+
+  @Get('balance/:agentId/current')
+  @RequireApiKey()
+  @ApiOperation({ summary: 'Get current balance for a specific agent' })
+  @ApiResponse({
+    status: 200,
+    description: 'Current balance retrieved successfully',
+  })
+  @ApiResponse({ status: 404, description: 'Agent not found' })
+  async getAgentCurrentBalance(
+    @Param('agentId') agentId: string,
+  ): Promise<any> {
+    return this.balanceAccountService.getAgentCurrentBalance(agentId);
+  }
 }

--- a/src/domains/kpi/kpi.module.ts
+++ b/src/domains/kpi/kpi.module.ts
@@ -4,9 +4,16 @@ import { KPIService } from './services/kpi.service';
 import { AccountBalanceTokens } from './interfaces';
 import { PerformanceSnapshotService } from './services/performance-snapshot.service';
 import { PerformanceSnapshotController } from './controllers/performance-snapshot.controller';
+import { MetricsController } from './controllers/metrics.controller';
+import { ElizaAgentModule } from '../leftcurve-agent/leftcurve-agent.module';
 
 @Module({
-  controllers: [KPIController, PerformanceSnapshotController],
+  imports: [ElizaAgentModule],
+  controllers: [
+    KPIController,
+    PerformanceSnapshotController,
+    MetricsController,
+  ],
   providers: [
     {
       provide: AccountBalanceTokens.AccountBalance,

--- a/src/domains/leftcurve-agent/leftcurve-agent.module.ts
+++ b/src/domains/leftcurve-agent/leftcurve-agent.module.ts
@@ -57,6 +57,12 @@ import { MessageService } from 'src/message/message.service';
     },
     PrismaService,
   ],
+  exports: [
+    {
+      provide: ServiceTokens.ElizaAgentQuery,
+      useClass: ElizaAgentQueryService,
+    },
+  ],
 })
 export class ElizaAgentModule implements OnModuleInit {
   constructor(

--- a/src/domains/trading-information/services/trading-information.service.ts
+++ b/src/domains/trading-information/services/trading-information.service.ts
@@ -58,11 +58,11 @@ export class TradingInformationService implements ITradingInformation {
     const trade = await this.prisma.tradingInformation.findUnique({
       where: { id },
     });
-    
+
     if (!trade) {
       return null;
     }
-    
+
     // Format trade to expose the information at the top level
     if (trade.information) {
       const info = trade.information as any;
@@ -76,7 +76,7 @@ export class TradingInformationService implements ITradingInformation {
         totalCost: info.totalCost || 0,
       } as TradingInformation;
     }
-    
+
     return trade;
   }
 


### PR DESCRIPTION
PR Title: Add Balance and Ranking Fields to LatestMarketData

Description:
This PR adds portfolio balance tracking and PnL ranking functionality to agent metrics:

## Changes
- Added `balanceInUSD` and `pnlRank` fields to the `LatestMarketData` model in Prisma schema
- Modified `SyncPerformanceMetricsTask` to:
  - Set TVL to 0 (per requirements)
  - Store portfolio balance in the new `balanceInUSD` field
  - Calculate and update agent rankings based on PnL performance
- Enhanced leaderboard endpoints to include the new fields:
  - Added balanceInUSD, pnlCycle, pnl24h, pnlRank, and tradeCount to all responses
  - Removed Token association requirement for left-curve and right-curve endpoints
  - Added a new `/api/leaderboard/pnl-leaderboard` endpoint for ranking agents by PnL

## Testing
- Verified all new fields are populated correctly in API responses
- Confirmed rankings are calculated properly (higher PnL = better rank)
- Tested endpoints with both LEFT and RIGHT curve agents

## Related Issues
[Link to related ticket/issue]