### PR TITLE
feature/agent-pnl-cycle-ranking

### DIFF
--- a/src/cron/tasks.service.ts
+++ b/src/cron/tasks.service.ts
@@ -206,35 +206,37 @@ export class TasksService {
   async updateAgentPerformanceSnapshots() {
     const startTime = Date.now();
     this.logger.log('Starting agent performance snapshot updates');
-    
+
     try {
       const agents = await this.prisma.elizaAgent.findMany({
-        where: { status: AgentStatus.RUNNING }
+        where: { status: AgentStatus.RUNNING },
       });
-      
+
       let successCount = 0;
       let failureCount = 0;
-      
+
       for (const agent of agents) {
         try {
-          await this.performanceSnapshotService.createAgentPerformanceSnapshot(agent.id);
+          await this.performanceSnapshotService.createAgentPerformanceSnapshot(
+            agent.id,
+          );
           successCount++;
         } catch (error) {
           failureCount++;
           this.logger.error(
-            `Failed to create performance snapshot for agent ${agent.id}: ${error.message}`
+            `Failed to create performance snapshot for agent ${agent.id}: ${error.message}`,
           );
         }
       }
-      
+
       const duration = Date.now() - startTime;
       this.logger.log(
-        `Performance snapshot updates completed - Success: ${successCount}, Failed: ${failureCount}, Duration: ${duration}ms`
+        `Performance snapshot updates completed - Success: ${successCount}, Failed: ${failureCount}, Duration: ${duration}ms`,
       );
     } catch (error) {
       const duration = Date.now() - startTime;
       this.logger.error(
-        `Failed to update agent performance snapshots (${duration}ms): ${error.message}`
+        `Failed to update agent performance snapshots (${duration}ms): ${error.message}`,
       );
     }
   }
@@ -249,18 +251,19 @@ export class TasksService {
   async cleanupPerformanceData() {
     const startTime = Date.now();
     this.logger.log('Starting performance data cleanup');
-    
+
     try {
-      const result = await this.performanceSnapshotService.applyDataRetentionPolicy();
-      
+      const result =
+        await this.performanceSnapshotService.applyDataRetentionPolicy();
+
       const duration = Date.now() - startTime;
       this.logger.log(
-        `Performance data cleanup completed - Deleted ${result.deleted} records, Duration: ${duration}ms`
+        `Performance data cleanup completed - Deleted ${result.deleted} records, Duration: ${duration}ms`,
       );
     } catch (error) {
       const duration = Date.now() - startTime;
       this.logger.error(
-        `Failed to clean up performance data (${duration}ms): ${error.message}`
+        `Failed to clean up performance data (${duration}ms): ${error.message}`,
       );
     }
   }


### PR DESCRIPTION
# Add PNL Cycle Ranking to Agent Performance Metrics

## Summary
This PR adds a ranking feature based on the agents' PNL cycle performance. Agents are now ranked in descending order based on their `pnlCycle` values, with rankings stored in the `pnlRank` field of the `LatestMarketData` model.

## Changes
- Added `updateAgentRankings()` method to `PerformanceSnapshotService`
- Added call to update rankings after each performance snapshot creation
- Updated `LatestMarketData` model to store rankings
- Ensured `balanceInUSD` is properly updated in performance snapshots
- Fixed linting issues in the tasks service

## Testing
Manually verified that:
- Rankings are properly calculated (higher PNL cycles get lower rank numbers)
- Rankings are updated when new snapshots are created
- Both the `pnlRank` and `balanceInUSD` fields are properly populated

## Note
This provides a way to show users their agent's ranking compared to others based on PNL performance.