### PR TITLE
feat/91-creator-leaderboard

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -339,6 +339,25 @@ model User {
   @@map("users")
 }
 
+model CreatorLeaderboardData {
+  id                    String   @id @default(uuid())
+  creatorWallet         String   @unique
+  totalAgents           Int      @default(0)
+  runningAgents         Int      @default(0)
+  totalBalanceInUSD     Float    @default(0)
+  aggregatedPnlCycle    Float    @default(0)
+  aggregatedPnl24h      Float    @default(0)
+  bestAgentId           String?
+  bestAgentPnlCycle     Float?
+  updatedAt             DateTime @updatedAt
+  createdAt             DateTime @default(now())
+
+  @@index([aggregatedPnlCycle])
+  @@index([totalBalanceInUSD])
+  @@index([runningAgents])
+  @@map("creator_leaderboard_data")
+}
+
 model ReferralCode {
   id           String    @id @default(cuid())
   code         String    @unique

--- a/src/cron/tasks.module.ts
+++ b/src/cron/tasks.module.ts
@@ -6,6 +6,7 @@ import { PrismaModule } from '../shared/prisma/prisma.module';
 import { AgentTokenModule } from '../domains/agent-token/agent-token.module';
 import { BlockchainModule } from '../shared/blockchain/blockchain.module';
 import { KPIModule } from '../domains/kpi/kpi.module';
+import { CreatorsModule } from '../domains/creators/creators.module';
 import { SyncPerformanceMetricsTask } from './tasks/sync-performance-metrics.task';
 
 @Module({
@@ -16,6 +17,7 @@ import { SyncPerformanceMetricsTask } from './tasks/sync-performance-metrics.tas
     AgentTokenModule,
     BlockchainModule,
     KPIModule,
+    CreatorsModule,
   ],
   providers: [TasksService, SyncPerformanceMetricsTask],
 })

--- a/src/domains/creators/controllers/creators.controller.ts
+++ b/src/domains/creators/controllers/creators.controller.ts
@@ -24,6 +24,8 @@ import {
   CreatorDto,
   AgentSummaryDto,
   CreatorPerformanceSummaryDto,
+  LeaderboardQueryDto,
+  CreatorLeaderboardEntryDto,
 } from '../dtos';
 import { RequireApiKey } from '../../../shared/auth/decorators/require-api-key.decorator';
 
@@ -49,6 +51,24 @@ export class CreatorsController {
     @Query(ValidationPipe) query: PageQueryDto,
   ): Promise<PaginatedResponseDto<CreatorDto>> {
     return this.creatorsService.findAllCreators(query);
+  }
+
+  @Get('leaderboard')
+  @RequireApiKey()
+  @ApiOperation({
+    summary: 'Get creator leaderboard ranked by performance metrics',
+  })
+  @ApiQuery({ type: LeaderboardQueryDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Sorted list of creators with their performance metrics',
+    type: () => PaginatedResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'API key is missing or invalid' })
+  async getCreatorLeaderboard(
+    @Query(ValidationPipe) query: LeaderboardQueryDto,
+  ): Promise<PaginatedResponseDto<CreatorLeaderboardEntryDto>> {
+    return this.creatorsService.getCreatorLeaderboard(query);
   }
 
   @Get(':creatorId')

--- a/src/domains/creators/controllers/creators.controller.ts
+++ b/src/domains/creators/controllers/creators.controller.ts
@@ -138,3 +138,4 @@ export class CreatorsController {
     return this.creatorsService.getCreatorPerformance(creatorId);
   }
 }
+ 

--- a/src/domains/creators/creators.module.ts
+++ b/src/domains/creators/creators.module.ts
@@ -21,3 +21,4 @@ const creatorsServiceProvider: Provider<ICreatorsService> = {
   ],
 })
 export class CreatorsModule {}
+ 

--- a/src/domains/creators/dtos/creator-leaderboard-entry.dto.ts
+++ b/src/domains/creators/dtos/creator-leaderboard-entry.dto.ts
@@ -1,0 +1,60 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreatorLeaderboardEntryDto {
+  @ApiProperty({
+    description: 'Creator wallet address',
+    example:
+      '0x046494be4b665b6182152e656d5eae6ec9dc8e8d8870851f11422fff1457736a',
+  })
+  creatorId: string;
+
+  @ApiProperty({
+    description: 'Total number of agents created by this creator',
+    example: 3,
+  })
+  totalAgents: number;
+
+  @ApiProperty({
+    description: 'Number of agents in RUNNING status',
+    example: 2,
+  })
+  runningAgents: number;
+
+  @ApiProperty({
+    description: 'Total USD balance across all agents',
+    example: 15000.5,
+  })
+  totalBalanceInUSD: number;
+
+  @ApiProperty({
+    description: 'Aggregated PnL for the current cycle across all agents',
+    example: 2500.75,
+  })
+  aggregatedPnlCycle: number;
+
+  @ApiProperty({
+    description: 'Aggregated 24-hour PnL across all agents',
+    example: 750.25,
+  })
+  aggregatedPnl24h: number;
+
+  @ApiProperty({
+    description: 'ID of the best performing agent by PnL cycle',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    required: false,
+  })
+  bestAgentId?: string;
+
+  @ApiProperty({
+    description: 'PnL cycle of the best performing agent',
+    example: 1250.5,
+    required: false,
+  })
+  bestAgentPnlCycle?: number;
+
+  @ApiProperty({
+    description: 'Timestamp when the leaderboard data was last updated',
+    example: '2023-04-30T14:30:00Z',
+  })
+  updatedAt: Date;
+}

--- a/src/domains/creators/dtos/index.ts
+++ b/src/domains/creators/dtos/index.ts
@@ -4,3 +4,5 @@ export * from './creator.dto';
 export * from './agent-summary.dto';
 export * from './creator-performance-agent-detail.dto';
 export * from './creator-performance-summary.dto';
+export * from './leaderboard-query.dto';
+export * from './creator-leaderboard-entry.dto';

--- a/src/domains/creators/dtos/index.ts
+++ b/src/domains/creators/dtos/index.ts
@@ -6,3 +6,4 @@ export * from './creator-performance-agent-detail.dto';
 export * from './creator-performance-summary.dto';
 export * from './leaderboard-query.dto';
 export * from './creator-leaderboard-entry.dto';
+ 

--- a/src/domains/creators/dtos/leaderboard-query.dto.ts
+++ b/src/domains/creators/dtos/leaderboard-query.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export enum LeaderboardSortField {
+  BALANCE = 'balance',
+  PNL_CYCLE = 'pnlCycle',
+  PNL_24H = 'pnl24h',
+  RUNNING_AGENTS = 'runningAgents',
+}
+
+export class LeaderboardQueryDto {
+  @ApiProperty({
+    description: 'Page number (starts at 1)',
+    example: 1,
+    default: 1,
+    required: false,
+  })
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  @IsOptional()
+  page?: number = 1;
+
+  @ApiProperty({
+    description: 'Number of items per page',
+    example: 10,
+    default: 10,
+    required: false,
+  })
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  @IsOptional()
+  limit?: number = 10;
+
+  @ApiProperty({
+    description: 'Field to sort by',
+    enum: LeaderboardSortField,
+    default: LeaderboardSortField.PNL_CYCLE,
+    required: false,
+  })
+  @IsEnum(LeaderboardSortField)
+  @IsOptional()
+  sortBy?: LeaderboardSortField = LeaderboardSortField.PNL_CYCLE;
+}

--- a/src/domains/creators/dtos/page-query.dto.ts
+++ b/src/domains/creators/dtos/page-query.dto.ts
@@ -26,3 +26,4 @@ export class PageQueryDto {
   @Type(() => Number)
   limit: number = 10;
 }
+ 

--- a/src/domains/creators/interfaces/creators-service.interface.ts
+++ b/src/domains/creators/interfaces/creators-service.interface.ts
@@ -3,6 +3,8 @@ import {
   PaginatedResponseDto,
   CreatorDto,
   AgentSummaryDto,
+  LeaderboardQueryDto,
+  CreatorLeaderboardEntryDto,
 } from '../dtos';
 import { CreatorPerformanceSummaryDto } from '../dtos/creator-performance-summary.dto';
 
@@ -33,4 +35,17 @@ export interface ICreatorsService {
   getCreatorPerformance(
     creatorId: string,
   ): Promise<CreatorPerformanceSummaryDto>;
+
+  /**
+   * Get leaderboard of creators sorted by performance metrics
+   */
+  getCreatorLeaderboard(
+    query: LeaderboardQueryDto,
+  ): Promise<PaginatedResponseDto<CreatorLeaderboardEntryDto>>;
+
+  /**
+   * Calculate and store leaderboard data for all creators
+   * (Used by cron job)
+   */
+  calculateAndStoreLeaderboard(): Promise<void>;
 }

--- a/src/domains/creators/interfaces/creators-service.interface.ts
+++ b/src/domains/creators/interfaces/creators-service.interface.ts
@@ -49,3 +49,4 @@ export interface ICreatorsService {
    */
   calculateAndStoreLeaderboard(): Promise<void>;
 }
+ 

--- a/src/domains/creators/services/creators.service.ts
+++ b/src/domains/creators/services/creators.service.ts
@@ -317,6 +317,7 @@ export class CreatorsService implements ICreatorsService {
 
     // Map to DTOs
     const leaderboardDtos = leaderboardEntries.map((entry) => ({
+      // Map the creator's wallet address to creatorId. The wallet address serves as the unique identifier for the creator.
       creatorId: entry.creatorWallet,
       totalAgents: entry.totalAgents,
       runningAgents: entry.runningAgents,
@@ -395,6 +396,7 @@ export class CreatorsService implements ICreatorsService {
         let aggregatedPnlCycle = 0;
         let aggregatedPnl24h = 0;
         let bestAgentId: string | null = null;
+        // Initialize best PnL to the lowest possible value to ensure any valid PnL becomes the initial best
         let bestAgentPnlCycle = -Infinity;
 
         // Process each agent for this creator

--- a/src/domains/creators/services/creators.service.ts
+++ b/src/domains/creators/services/creators.service.ts
@@ -413,8 +413,8 @@ export class CreatorsService implements ICreatorsService {
             aggregatedPnl24h += marketData.pnl24h || 0;
 
             // Update best agent if this one has better PnL cycle
-            if ((marketData.pnlCycle || -Infinity) > bestAgentPnlCycle) {
-              bestAgentPnlCycle = marketData.pnlCycle || -Infinity;
+            if ((marketData.pnlCycle ?? -Infinity) > bestAgentPnlCycle) {
+              bestAgentPnlCycle = marketData.pnlCycle ?? -Infinity;
               bestAgentId = agent.id;
             }
           }


### PR DESCRIPTION
## Overview

This pull request implements the Creator Leaderboard feature as defined in Issue #91. It introduces a new API endpoint (`GET /api/creators/leaderboard`) that provides a paginated and sortable list of creators based on their aggregated performance metrics.

## Implementation Details

### Approach: Pre-Calculation

To ensure responsiveness and scalability, this feature uses a pre-calculation approach:

1.  **New Database Model:** A new table, `creator_leaderboard_data`, has been added to the database to store the calculated leaderboard data for each creator. The Prisma schema (`prisma/schema.prisma`) has been updated with the `CreatorLeaderboardData` model.
2.  **Calculation Logic:** A new method, `calculateAndStoreLeaderboard()`, has been added to `CreatorsService`. This method:
    *   Fetches all unique creators.
    *   For each creator, aggregates performance data (total agents, running agents, total balance, PnL cycle, PnL 24h, best agent) from their agents' `LatestMarketData`.
    *   Upserts the aggregated data into the `creator_leaderboard_data` table.
3.  **Cron Job:** An hourly cron job, `updateCreatorLeaderboard`, has been added to `TasksService`. This job calls `calculateAndStoreLeaderboard()` periodically to keep the leaderboard data refreshed.
4.  **API Endpoint:**
    *   The `GET /api/creators/leaderboard` endpoint in `CreatorsController` retrieves data directly from the pre-calculated `creator_leaderboard_data` table.
    *   It supports pagination (`page`, `limit`) and sorting (`sortBy`) based on fields like `pnlCycle`, `balance`, `pnl24h`, and `runningAgents` via the `LeaderboardQueryDto`.
    *   The response uses the `CreatorLeaderboardEntryDto` for individual entries and `PaginatedResponseDto` for the overall structure.

### New Components

*   **Model:** `prisma/schema.prisma` -> `CreatorLeaderboardData`
*   **DTOs:**
    *   `src/domains/creators/dtos/leaderboard-query.dto.ts`
    *   `src/domains/creators/dtos/creator-leaderboard-entry.dto.ts`
*   **Service:** `src/domains/creators/services/creators.service.ts` -> `getCreatorLeaderboard()`, `calculateAndStoreLeaderboard()`
*   **Controller:** `src/domains/creators/controllers/creators.controller.ts` -> `getCreatorLeaderboard()`
*   **Cron:** `src/cron/tasks.service.ts` -> `updateCreatorLeaderboard()`
*   **Module:** `src/cron/tasks.module.ts` updated to import `CreatorsModule`.

## Testing

The implementation was tested through the following steps:

1.  **Initial Endpoint Test:** Used `curl` to query the `GET /api/creators/leaderboard` endpoint. Verified it returned a 200 status and an empty, correctly structured response, as the calculation hadn't run yet.
2.  **Manual Calculation Trigger:** Temporarily added a `POST /api/creators/leaderboard/calculate` endpoint to manually trigger the `calculateAndStoreLeaderboard` service method. Called this endpoint using `curl`.
3.  **Post-Calculation Verification:** Waited a few seconds for the calculation to complete and used `curl` again to query the `GET /api/creators/leaderboard` endpoint. Verified that the endpoint now returned populated data, correctly aggregated and structured according to the DTOs.
4.  **Cleanup:** Removed the temporary `POST` endpoint used for testing.
5.  Standard unit and integration tests should also be added to cover the service logic and controller endpoints thoroughly.

## Deployment Instructions

When deploying this feature to production, the new database table needs to be created by running the Prisma migration.

**Recommended Production Migration Process:**

1.  **Build Application:** Build the production artifact for the application.
2.  **Run Migrations:** Before starting the new application version, run the following command in the production environment (typically as part of a CI/CD pipeline or deployment script):
    ```bash
    npx prisma migrate deploy
    ```
    This command applies all pending migrations (including the one adding `creator_leaderboard_data`) non-interactively. It's safe to run even if no migrations are pending.
3.  **Start New Version:** Start the updated application instance(s). The application will now be able to interact with the new table.
4.  **Cron Job:** The `updateCreatorLeaderboard` cron job will automatically start running on its schedule (hourly) once the application is running. The first run will populate the leaderboard data.

## Estimated Time

The estimated time to complete this feature, including analysis, design, implementation, testing, and documentation, is approximately ** 14 hours**.