### PR TITLE
Add endpoint to sequentially send market analysis and portfolio allocation requests

### DIFF
--- a/src/message/dtos/trade-portfolio-request.dto.ts
+++ b/src/message/dtos/trade-portfolio-request.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsOptional, IsNumber } from 'class-validator';
+
+export class TradePortfolioRequestDto {
+  @ApiProperty({
+    description: 'Runtime ID of the agent',
+    example: 'agent-123456',
+  })
+  @IsString()
+  @IsNotEmpty()
+  runtimeAgentId: string;
+
+  @ApiProperty({
+    description: 'Delay in milliseconds between trade request and portfolio request',
+    example: 20000,
+    required: false,
+  })
+  @IsNumber()
+  @IsOptional()
+  delayBetweenRequests?: number;
+} 

--- a/src/message/message.controller.ts
+++ b/src/message/message.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Post,
+  Body,
+  UseInterceptors,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { LoggingInterceptor } from '../shared/interceptors/logging.interceptor';
+import { RequireApiKey } from '../shared/auth/decorators/require-api-key.decorator';
+import { MessageService } from './message.service';
+import { TradePortfolioRequestDto } from './dtos/trade-portfolio-request.dto';
+
+@ApiTags('Messages')
+@Controller('api/messages')
+@UseInterceptors(LoggingInterceptor)
+export class MessageController {
+  constructor(private readonly messageService: MessageService) {}
+
+  @Post('trade-portfolio')
+  @RequireApiKey()
+  @ApiOperation({
+    summary: 'Send trade decision and portfolio allocation requests to an agent',
+    description: 'Sends two sequential requests to an agent: first a market analysis and trade decision request, followed by a portfolio allocation request after a specified delay.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Requests sent successfully',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Agent not found or not ready',
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Failed to send the requests',
+  })
+  async sendTradeAndPortfolioRequests(@Body() dto: TradePortfolioRequestDto) {
+    try {
+      const result = await this.messageService.sendTradeAndPortfolioRequests(
+        dto.runtimeAgentId,
+        dto.delayBetweenRequests,
+      );
+      
+      return {
+        status: 'success',
+        data: result,
+      };
+    } catch (error) {
+      if (error.message.includes('not found') || error.message.includes('not ready')) {
+        throw new HttpException(
+          `Agent not found or not ready: ${error.message}`,
+          HttpStatus.NOT_FOUND,
+        );
+      }
+      
+      throw new HttpException(
+        `Failed to send requests: ${error.message}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+} 

--- a/src/message/message.module.ts
+++ b/src/message/message.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { MessageService } from './message.service';
+import { MessageController } from './message.controller';
 
 @Module({
+  controllers: [MessageController],
   providers: [MessageService],
   exports: [MessageService],
 })

--- a/src/message/message.service.ts
+++ b/src/message/message.service.ts
@@ -148,4 +148,63 @@ export class MessageService {
       throw error;
     }
   }
+
+  /**
+   * Sends the market analysis request followed by portfolio allocation request to an agent
+   * @param runtimeAgentId The runtime ID of the agent
+   * @param delayBetweenRequests Delay in milliseconds between the two requests
+   */
+  async sendTradeAndPortfolioRequests(
+    runtimeAgentId: string,
+    delayBetweenRequests = 20000, // 20 seconds default delay
+  ) {
+    try {
+      this.logger.log(
+        `Sending market analysis and portfolio requests to agent with runtime ID: ${runtimeAgentId}`,
+      );
+
+      // First request: market analysis and trade decision
+      const tradeDecisionRequest = {
+        content: {
+          text: "Examine the current Paradex markets and decide whether to make a trade based on YOUR unique trading philosophy and character traits First, use get_analysis_paradex to review the latest technical indicators. Then, carefully consider: 1) Do the current market conditions truly align with your personal trading style and risk tolerance? 2) Would trading now reflect your character's distinct approach to markets?Remember that NOT trading is often the most prudent decision. There's no pressure to execute a trade - only do so if it genuinely makes sense for your specific character. If you decide to trade, use simulate_trade and focus your explanation on how this specific opportunity matches your unique perspective. Mention only the 1-2 most relevant technical factors without listing every indicator. If you decided to trade, use print_portfolio and send_portfolio_balance to track your position. The most important thing is that your decision authentically reflects your character - don't trade unless it truly fits your personality and trading philosophy.",
+        },
+      };
+
+      // Send first request
+      await this.sendMessageToAgent(runtimeAgentId, tradeDecisionRequest);
+      
+      this.logger.log(
+        `Trade decision request sent successfully. Waiting ${
+          delayBetweenRequests / 1000
+        } seconds before sending portfolio allocation request...`,
+      );
+
+      // Wait before sending the second request
+      await new Promise((resolve) => setTimeout(resolve, delayBetweenRequests));
+
+      // Second request: portfolio allocation
+      const portfolioAllocationRequest = {
+        content: {
+          text: "Review the available analysis and tradable cryptos, then define your portfolio allocation across five selected cryptos and USDC.",
+        },
+      };
+
+      // Send second request
+      await this.sendMessageToAgent(runtimeAgentId, portfolioAllocationRequest);
+      
+      this.logger.log(
+        `Portfolio allocation request sent successfully to agent with runtime ID: ${runtimeAgentId}`,
+      );
+
+      return { 
+        success: true, 
+        message: 'Both requests sent successfully' 
+      };
+    } catch (error) {
+      this.logger.error(
+        `Failed to send requests to agent with runtime ID ${runtimeAgentId}: ${error.message}`,
+      );
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
## Description
This PR adds a new API endpoint that sends two requests to an agent in sequence:
1. First, a market analysis and trade decision request
2. After a configurable delay, a portfolio allocation request

## Implementation
- Created `POST /api/messages/trade-portfolio` endpoint
- Added validation for the request parameters
- Implemented sequencing with configurable delay between requests

## Usage
```bash
curl -X POST "http://localhost:8080/api/messages/trade-portfolio" \
  -H "Content-Type: application/json" \
  -H "x-api-key: secret" \
  -d '{"runtimeAgentId": "AGENT_ID", "delayBetweenRequests": 15000}'
```

## Benefits
Simplifies the process of requesting trade decisions and portfolio allocations from agents with proper timing between requests.