### PR TITLE
feat: Enhance Creator Performance & Leaderboard

### DIFF
--- a/prisma/migrations/20250515080214_add_total_trade_count_to_leaderboard/migration.sql
+++ b/prisma/migrations/20250515080214_add_total_trade_count_to_leaderboard/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "creator_leaderboard_data" ADD COLUMN     "totalTradeCount" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -347,6 +347,7 @@ model CreatorLeaderboardData {
   totalBalanceInUSD     Float    @default(0)
   aggregatedPnlCycle    Float    @default(0)
   aggregatedPnl24h      Float    @default(0)
+  totalTradeCount       Int      @default(0)
   bestAgentId           String?
   bestAgentPnlCycle     Float?
   updatedAt             DateTime @updatedAt

--- a/src/cron/tasks.service.ts
+++ b/src/cron/tasks.service.ts
@@ -199,6 +199,7 @@ export class TasksService {
     );
   }
 
+  // Runs every hour to generate asset analysis for tradable cryptocurrencies on Paradex.
   @Cron(CronExpression.EVERY_HOUR)
   async generateParadexAnalysis() {
     try {
@@ -228,6 +229,7 @@ export class TasksService {
   //   }
   // }
 
+  // Runs every 2 hours at minute 0 to send a trade simulation order to active agents.
   @Cron('0 */2 * * *')
   async sendTradeSimulation() {
     const startTime = Date.now();
@@ -273,6 +275,7 @@ export class TasksService {
    * Update agent performance snapshots every hour
    * This captures historical data for agent performance metrics including PnL
    */
+  // Runs every hour at minute 0 to update agent performance snapshots.
   @Cron('0 * * * *') // Run every hour at minute 0
   async updateAgentPerformanceSnapshots() {
     const startTime = Date.now();
@@ -312,7 +315,8 @@ export class TasksService {
     }
   }
 
-  @Cron(CronExpression.EVERY_HOUR)
+  // Runs every 5 minutes to calculate and store creator leaderboard data.
+  @Cron('*/5 * * * *')
   async updateCreatorLeaderboard() {
     const startTime = Date.now();
     this.logger.log('Starting creator leaderboard update');
@@ -338,6 +342,7 @@ export class TasksService {
    * - Keep daily data for 90 days
    * - Weekly data is kept indefinitely
    */
+  // Runs daily at midnight to apply data retention policy for performance snapshots.
   @Cron('0 0 * * *') // Run daily at midnight
   async cleanupPerformanceData() {
     const startTime = Date.now();

--- a/src/domains/creators/dtos/creator-leaderboard-entry.dto.ts
+++ b/src/domains/creators/dtos/creator-leaderboard-entry.dto.ts
@@ -39,6 +39,12 @@ export class CreatorLeaderboardEntryDto {
   aggregatedPnl24h: number;
 
   @ApiProperty({
+    description: 'Total number of trades executed by all agents of this creator',
+    example: 1500,
+  })
+  totalTradeCount: number;
+
+  @ApiProperty({
     description: 'ID of the best performing agent by PnL cycle',
     example: '123e4567-e89b-12d3-a456-426614174000',
     required: false,

--- a/src/domains/creators/dtos/creator-performance-agent-detail.dto.ts
+++ b/src/domains/creators/dtos/creator-performance-agent-detail.dto.ts
@@ -16,11 +16,41 @@ export class CreatorPerformanceAgentDetailDto {
   status: AgentStatus;
 
   @ApiProperty({
-    description: 'Agent Profile Picture URL',
+    description: 'Agent Profile Picture filename',
     required: false,
-    example: '/path/to/image.jpg',
+    example: 'image.jpg',
   })
   profilePicture?: string;
+
+  @ApiProperty({
+    description: 'Full URL to agent profile picture',
+    required: false,
+    example: '/uploads/profile-pictures/image.jpg',
+  })
+  profilePictureUrl?: string | null;
+
+  @ApiProperty({
+    description: 'Token Symbol',
+    required: false,
+    example: 'AGENT',
+  })
+  symbol?: string;
+
+  @ApiProperty({
+    description: 'P&L Cycle Ranking',
+    required: false,
+    type: Number,
+    example: 1,
+  })
+  pnlRank?: number | null;
+
+  @ApiProperty({
+    description: 'Number of times this agent has been forked',
+    required: false,
+    type: Number,
+    example: 5,
+  })
+  forkCount?: number | null;
 
   @ApiProperty({
     description: 'Agent Current Balance in USD',

--- a/src/domains/creators/services/creators.service.ts
+++ b/src/domains/creators/services/creators.service.ts
@@ -148,6 +148,7 @@ export class CreatorsService implements ICreatorsService {
       },
       include: {
         LatestMarketData: true, // Eager load latest data
+        Token: true, // Include token data for symbol
       },
     });
 
@@ -179,7 +180,14 @@ export class CreatorsService implements ICreatorsService {
       agentDetailDto.name = agent.name;
       agentDetailDto.status = agent.status;
       agentDetailDto.profilePicture = agent.profilePicture || undefined;
+      // Add the full profile picture URL
+      agentDetailDto.profilePictureUrl = agent.profilePicture
+        ? `/uploads/profile-pictures/${agent.profilePicture}`
+        : null;
       agentDetailDto.createdAt = agent.createdAt;
+
+      // Add token symbol if available
+      agentDetailDto.symbol = agent.Token?.symbol;
 
       // Check if agent has market data
       if (agent.LatestMarketData) {
@@ -192,6 +200,9 @@ export class CreatorsService implements ICreatorsService {
         agentDetailDto.pnl24h = marketData.pnl24h;
         agentDetailDto.tradeCount = marketData.tradeCount;
         agentDetailDto.marketCap = marketData.marketCap;
+        // Add the new fields from LatestMarketData
+        agentDetailDto.pnlRank = marketData.pnlRank;
+        agentDetailDto.forkCount = marketData.forkCount;
 
         // Update aggregators using helper method
         aggregators = this._updateAggregators(aggregators, marketData);
@@ -218,6 +229,8 @@ export class CreatorsService implements ICreatorsService {
         agentDetailDto.pnl24h = null;
         agentDetailDto.tradeCount = null;
         agentDetailDto.marketCap = null;
+        agentDetailDto.pnlRank = null;
+        agentDetailDto.forkCount = null;
       }
 
       // Count running agents
@@ -324,6 +337,7 @@ export class CreatorsService implements ICreatorsService {
       totalBalanceInUSD: entry.totalBalanceInUSD,
       aggregatedPnlCycle: entry.aggregatedPnlCycle,
       aggregatedPnl24h: entry.aggregatedPnl24h,
+      totalTradeCount: entry.totalTradeCount,
       bestAgentId: entry.bestAgentId || undefined,
       bestAgentPnlCycle: entry.bestAgentPnlCycle || undefined,
       updatedAt: entry.updatedAt,
@@ -395,6 +409,7 @@ export class CreatorsService implements ICreatorsService {
         let totalBalanceInUSD = 0;
         let aggregatedPnlCycle = 0;
         let aggregatedPnl24h = 0;
+        let totalTradeCountForCreator = 0; // Initialize total trade count for the creator
         let bestAgentId: string | null = null;
         // Initialize best PnL to the lowest possible value to ensure any valid PnL becomes the initial best
         let bestAgentPnlCycle = -Infinity;
@@ -414,6 +429,7 @@ export class CreatorsService implements ICreatorsService {
             totalBalanceInUSD += marketData.balanceInUSD || 0;
             aggregatedPnlCycle += marketData.pnlCycle || 0;
             aggregatedPnl24h += marketData.pnl24h || 0;
+            totalTradeCountForCreator += marketData.tradeCount || 0; // Aggregate trade count
 
             // Update best agent if this one has better PnL cycle
             if ((marketData.pnlCycle ?? -Infinity) > bestAgentPnlCycle) {
@@ -434,6 +450,7 @@ export class CreatorsService implements ICreatorsService {
             totalBalanceInUSD,
             aggregatedPnlCycle,
             aggregatedPnl24h,
+            totalTradeCount: totalTradeCountForCreator,
             bestAgentId,
             bestAgentPnlCycle:
               bestAgentPnlCycle !== -Infinity ? bestAgentPnlCycle : null,
@@ -445,6 +462,7 @@ export class CreatorsService implements ICreatorsService {
             totalBalanceInUSD,
             aggregatedPnlCycle,
             aggregatedPnl24h,
+            totalTradeCount: totalTradeCountForCreator,
             bestAgentId,
             bestAgentPnlCycle:
               bestAgentPnlCycle !== -Infinity ? bestAgentPnlCycle : null,


### PR DESCRIPTION
This pull request introduces significant enhancements to the creator-focused API endpoints, providing richer data for both the global creator leaderboard and individual creator performance views.

**Key Changes:**

1.  **Creator Leaderboard - Added Total Trade Count:**
    *   The `CreatorLeaderboardData` Prisma model now includes a `totalTradeCount` field.
    *   A new database migration (`add_total_trade_count_to_leaderboard`) has been added for this schema change.
    *   The `calculateAndStoreLeaderboard` service method in `CreatorsService` now aggregates the `tradeCount` from each agent's `LatestMarketData` and stores this sum for each creator.
    *   The `CreatorLeaderboardEntryDto` and the `/api/creators/leaderboard` endpoint response now include this `totalTradeCount`.

2.  **Enhanced Creator Performance Endpoint (`/api/creators/{creatorId}/performance`):**
    *   The `CreatorPerformanceAgentDetailDto` has been updated to include more comprehensive agent information:
        *   `profilePictureUrl`: Provides the full URL for the agent's profile picture.
        *   `symbol`: The agent's token symbol (from the related `AgentToken`).
        *   `pnlRank`: The agent's P&L cycle ranking.
        *   `forkCount`: The number of times the agent has been forked.
    *   The `CreatorsService.getCreatorPerformance()` method now:
        *   Includes the `Token` relation in its Prisma query.
        *   Populates these new fields for each agent listed under a creator.
        *   Continues to provide aggregated creator-level KPIs (total balance, total agents, best PnL, etc.).

3.  **Cron Job Schedule Adjustments (`src/cron/tasks.service.ts`):**
    *   The `updateCreatorLeaderboard` cron job schedule has been changed from hourly to **every 5 minutes** to provide more up-to-date leaderboard data.
    *   Descriptive comments have been added above all cron job definitions to clarify their purpose and schedule.

**Impact:**

*   The UI will now have access to the total trade count for creators on the leaderboard.
*   When viewing a specific creator's performance, the UI can display more detailed information for each of their agents, aligning better with `UIAgent` type expectations (including token symbol, rankings, fork counts, and full profile picture URLs).
*   The leaderboard will refresh more frequently.

These changes aim to provide a more comprehensive and near real-time view of creator and agent performance.