### PR TITLE
Add trading strategy request sequence after agent initialization

### DIFF
--- a/src/domains/leftcurve-agent/orchestration/steps/start-container.step.ts
+++ b/src/domains/leftcurve-agent/orchestration/steps/start-container.step.ts
@@ -14,7 +14,7 @@ import { PerformanceSnapshotService } from 'src/domains/kpi/services/performance
 @Injectable()
 export class StartContainerStep extends BaseStepExecutor {
   private readonly logger = new Logger(StartContainerStep.name);
-  private readonly delayBetweenRequests = 10000; // 10 seconds delay
+  private readonly delayBetweenRequests = 8000; // 8 seconds delay
 
   constructor(
     @Inject(ServiceTokens.Docker)
@@ -81,7 +81,7 @@ export class StartContainerStep extends BaseStepExecutor {
       );
       await this.messageService.sendMessageToAgent(runtimeAgentId, {
         content: {
-          text: "Review the available analysis and tradable cryptos. Then, based on current market conditions and the five cryptos assigned to you (plus USDC), define your portfolio allocation strategy accordingly.",
+          text: "Review the available analysis and tradable cryptos. Then, based on current market conditions and the five cryptos assigned to you (plus USDC), define your portfolio allocation strategy accordingly (with set_target_allocation action).",
         },
       });
       
@@ -103,7 +103,7 @@ export class StartContainerStep extends BaseStepExecutor {
       );
       await this.messageService.sendMessageToAgent(runtimeAgentId, {
         content: {
-          text: "Based on market conditions and your trading personality, define an entry and exit strategy for the five cryptos assigned to you.",
+          text: "Based on market conditions and your trading personality, define an entry and exit strategy for the five cryptos assigned to you (with set_strategy_text action).",
         },
       });
       

--- a/src/domains/leftcurve-agent/orchestration/steps/start-container.step.ts
+++ b/src/domains/leftcurve-agent/orchestration/steps/start-container.step.ts
@@ -14,7 +14,7 @@ import { PerformanceSnapshotService } from 'src/domains/kpi/services/performance
 @Injectable()
 export class StartContainerStep extends BaseStepExecutor {
   private readonly logger = new Logger(StartContainerStep.name);
-  private readonly delayBetweenRequests = 20000; // 20 seconds delay
+  private readonly delayBetweenRequests = 10000; // 10 seconds delay
 
   constructor(
     @Inject(ServiceTokens.Docker)
@@ -87,6 +87,28 @@ export class StartContainerStep extends BaseStepExecutor {
       
       this.logger.log(
         `Portfolio allocation request sent successfully to agent with runtime ID: ${runtimeAgentId}`
+      );
+
+      // Wait before sending the trading strategy request
+      this.logger.log(
+        `Waiting ${this.delayBetweenRequests / 1000} seconds before sending trading strategy request...`
+      );
+      
+      // Wait for the specified delay again
+      await new Promise((resolve) => setTimeout(resolve, this.delayBetweenRequests));
+
+      // Third request: trading strategy
+      this.logger.log(
+        `Sending trading strategy request to agent with runtime ID: ${runtimeAgentId}`
+      );
+      await this.messageService.sendMessageToAgent(runtimeAgentId, {
+        content: {
+          text: "Based on market conditions and your trading personality, define an entry and exit strategy for the five cryptos assigned to you.",
+        },
+      });
+      
+      this.logger.log(
+        `Trading strategy request sent successfully to agent with runtime ID: ${runtimeAgentId}`
       );
 
       return this.success(updatedAgent, {


### PR DESCRIPTION
## Changes
- Add third sequential request for trading strategy definition using `set_strategy_text` action
- Reduce delay between requests from 20s to 8s for faster agent initialization
- Update portfolio allocation request to include `set_target_allocation` action hint

## Why
Complete the agent initialization flow with a third step that prompts agents to define entry/exit strategies aligned with their trading personalities, resulting in more comprehensive agent behavior from startup.